### PR TITLE
Fix lookup return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,14 +65,14 @@ export default class WhoisLight {
   /**
    * Performs a bulk whois lookup for several specified domain names. Returning the raw whois results.
    * @param options Optional options parameter.
-   * @param namesDomain names to preform lookup on.
+   * @param names Domain names to preform lookup on.
    * @returns Conditionally raw result or formatted result depending on options.format
    */
    static bulkLookup(options: WhoisLightOptions, names: string[]): Promise<WhoisLightBulkResult<WhoisLightRawResult | WhoisLightFormattedResult>>;
 
    /**
     * Performs a bulk whois lookup for several specified domain names. Returning the raw whois results.
-    * @param namesDomain names to preform lookup on.
+    * @param names Domain names to preform lookup on.
     */
    static bulkLookup(names: string[]): Promise<WhoisLightBulkResult<WhoisLightRawResult>>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ export interface WhoisLightOptions {
 
 export type WhoisLightRawResult = string;
 export type WhoisLightFormattedResult = Record<string, string>;
+export type WhoisLightLookupResult<T extends WhoisLightOptions> = T['format'] extends true ? WhoisLightFormattedResult : WhoisLightRawResult
 export type WhoisLightBulkResult<T> = Record<string, T>
 
 export default class WhoisLight {
@@ -54,7 +55,7 @@ export default class WhoisLight {
    * @param name Domain name to preform whois lookup on.
    * @returns Conditionally raw result or formatted result depending on options.format
    */
-  static lookup(options: WhoisLightOptions, name: string): Promise<WhoisLightRawResult | WhoisLightFormattedResult>;
+  static lookup<T extends WhoisLightOptions>(options: T, name: string): Promise<WhoisLightLookupResult<T>>;
 
   /**
    * Performs a whois lookup for the specified domain name. Returning the raw whois results.
@@ -68,7 +69,7 @@ export default class WhoisLight {
    * @param names Domain names to preform lookup on.
    * @returns Conditionally raw result or formatted result depending on options.format
    */
-   static bulkLookup(options: WhoisLightOptions, names: string[]): Promise<WhoisLightBulkResult<WhoisLightRawResult | WhoisLightFormattedResult>>;
+   static bulkLookup<T extends WhoisLightOptions>(options: T, names: string[]): Promise<WhoisLightBulkResult<WhoisLightLookupResult<T>>>;
 
    /**
     * Performs a bulk whois lookup for several specified domain names. Returning the raw whois results.


### PR DESCRIPTION
Make `lookup` return type `WhoisLightFormattedResult` or `WhoisLightRawResult` depending on `options.format`